### PR TITLE
feat: initiate child actions

### DIFF
--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "3.9.7-pnpify",
+  "version": "4.0.2-pnpify",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/uuid": "^8.3.0",
     "@yarnpkg/pnpify": "^2.1.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.2"
   },
   "dependencies": {
     "uuid": "^8.3.0"

--- a/src/de.ts
+++ b/src/de.ts
@@ -1,12 +1,12 @@
 import * as uuid from 'uuid';
 
 import {
-  CreateDomainEventArgs, CreateDomainEventReturnType, IDomainEvent, IDomainEventAdapter,
+  CreateDomainEventArgs, CreateDomainEventReturnType, IDomainEvent, IDomainEventHooks,
   IDomainHandler,
 } from './interface';
 
 export class DomainEvents {
-  constructor(private readonly adapter?: IDomainEventAdapter) { }
+  constructor(private readonly hooks?: IDomainEventHooks) { }
 
   private readonly eventMap: Map<IDomainEvent['type'], IDomainHandler<any>[]> = new Map();
 
@@ -53,7 +53,7 @@ export class DomainEvents {
 
     for (const [eventType, handlers] of this.eventMap.entries()) {
       if (eventType === event.type) {
-        await this.adapter?.beforeInvoke?.(returnEvent);
+        await this.hooks?.beforeInvoke?.(returnEvent);
 
         returnEvent = {
           ...returnEvent,
@@ -112,7 +112,7 @@ export class DomainEvents {
           completedAt: Date.now(),
         };
 
-        await this.adapter?.afterInvoke?.(returnEvent);
+        await this.hooks?.afterInvoke?.(returnEvent);
 
         // if complete callback threw an error, rethrow it. we need
         // this check to make sure the adapter is called before throwing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from './de';
-export { IDomainEvent, IDomainEventAdapter, IDomainHandler } from './interface';
+export { IDomainEvent, IDomainEventHooks, IDomainHandler } from './interface';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -28,7 +28,7 @@ export interface IDomainHandler<T extends IDomainEvent> {
   complete?: (event: T, childEvents: IDomainEvent[]) => T | undefined;
 }
 
-export interface IDomainEventAdapter {
+export interface IDomainEventHooks {
   beforeInvoke?: (event: IDomainEvent) => void | Promise<void>;
   afterInvoke?: (event: IDomainEvent) => void | Promise<void>;
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -23,8 +23,8 @@ type PureActionReturnType = void | IDomainEvent[];
 type ImpureActionReturnType = PureActionReturnType | Promise<PureActionReturnType>;
 
 export interface IDomainHandler<T extends IDomainEvent> {
-  initiate?: (event: T) => T | Promise<T>;
-  execute?: (event: T) => ImpureActionReturnType;
+  initiate?: (event: T) => ImpureActionReturnType;
+  execute?: (event: T, childEvents: IDomainEvent[]) => ImpureActionReturnType;
   complete?: (event: T, childEvents: IDomainEvent[]) => T | undefined;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,7 +47,7 @@ __metadata:
   dependencies:
     "@types/uuid": ^8.3.0
     "@yarnpkg/pnpify": ^2.1.0
-    typescript: ^3.9.7
+    typescript: ^4.0.2
     uuid: ^8.3.0
   languageName: unknown
   linkType: soft
@@ -1231,23 +1231,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-typescript@^3.9.7:
-  version: 3.9.7
-  resolution: "typescript@npm:3.9.7"
+typescript@^4.0.2:
+  version: 4.0.2
+  resolution: "typescript@npm:4.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10848a9c35fd8c70a8792b8bd9485317534bcd58768793d3b7d9c7486e9fd30cf345f83fa2a324e0bf6088bc8a4d8d061d58fda38b18c2ff187cf01fbbff6267
+  checksum: cc0e7806eee7997a1b4b2990badacc4a8d089893ed0a377f35c9658e2ac392503cb340d0187203ed82e36e427dda94b0fb7107e44a71cca99efac86be26e16ee
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.9.7#builtin<compat/typescript>":
-  version: 3.9.7
-  resolution: "typescript@patch:typescript@npm%3A3.9.7#builtin<compat/typescript>::version=3.9.7&hash=5b02a2"
+"typescript@patch:typescript@^4.0.2#builtin<compat/typescript>":
+  version: 4.0.2
+  resolution: "typescript@patch:typescript@npm%3A4.0.2#builtin<compat/typescript>::version=4.0.2&hash=5b02a2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f0d3d9c987860c7c458229ab6dd7e3d322405db36b70abccba610b5efd9f9451e4e67a3fc7983c0d3741033c1f1a8d7aa859a1510caa8f20fad762fc39648bfa
+  checksum: b8b689ef994cce4fe59950d56ddfffce3c4bdda8edb85b72e752d4a6d27bf7df8a318e76ccde25cbe6e642058f2f4ccf47187db4b243bbc98278a2844db9461b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes the way events work. Instead of returning event from initiate, now we return child actions that are executed before the `execute` phase.

The flow looks like this:
1. parent.initiate
1. child.initiate
1. child.execute
1. child.complete
1. parent.execute
1. parent.complete